### PR TITLE
Add Scala version-specific source for Play and Picopickle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,10 @@ dist: trusty
 scala:
   - 2.10.6
   - 2.11.8
+  - 2.12.1
 
 jdk:
-  - oraclejdk7
   - oraclejdk8
-
-matrix:
-  include:
-  - scala: 2.12.1
-    jdk: oraclejdk8
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 
+matrix:
+  include:
+  - scala: 2.12.1
+    jdk: oraclejdk8
+
 cache:
   directories:
     - $HOME/.ivy2/cache

--- a/build.sbt
+++ b/build.sbt
@@ -44,24 +44,36 @@ val baseSettings = Seq(
 
 val circeDependencies = Seq(
   "io.circe" %% "circe-core",
-  "io.circe" %% "circe-generic",
   "io.circe" %% "circe-jawn"
 ).map(_ % circeVersion)
 
 lazy val benchmark = project.in(file("."))
   .settings(baseSettings ++ noPublishSettings)
   .settings(
-    scalaVersion := "2.11.8",
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-json" % "2.3.10",
-      "io.argonaut" %% "argonaut" % "6.1",
+      "io.argonaut" %% "argonaut" % "6.2-RC2",
       "io.spray" %% "spray-json" % "1.3.2",
-      "io.github.netvl.picopickle" %% "picopickle-core" % "0.2.1",
-      "io.github.netvl.picopickle" %% "picopickle-backend-jawn" % "0.2.1",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     ),
-    libraryDependencies ++= circeDependencies
+    libraryDependencies ++= circeDependencies,
+    libraryDependencies ++= (
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 10)) => Nil
+        case _ => Seq(
+          "com.typesafe.play" %% "play-json" % "2.6.0-M1"
+        )
+      }
+    ),
+    libraryDependencies ++= (
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 12)) => Nil
+        case _ => Seq(
+          "io.github.netvl.picopickle" %% "picopickle-core" % "0.3.1",
+          "io.github.netvl.picopickle" %% "picopickle-backend-jawn" % "0.3.1"
+        )
+      }
+    )
   )
   .enablePlugins(JmhPlugin)
 

--- a/src/main/scala-2.10/io/circe/benchmarks/PicopickleDefinitions.scala
+++ b/src/main/scala-2.10/io/circe/benchmarks/PicopickleDefinitions.scala
@@ -1,0 +1,50 @@
+package io.circe.benchmarks
+
+import io.github.netvl.picopickle.backends.jawn.JsonPickler
+import io.github.netvl.picopickle.backends.jawn.JsonPickler._
+import org.openjdk.jmh.annotations._
+
+/**
+ * Note that this file appears in both the scala-2.10 and scala-2.11 source trees, and any changes
+ * should be reflected in both places.
+ */
+trait PicopickleFooInstances
+
+trait PicopickleData { self: ExampleData =>
+  @inline def encodePico[A](a: A)(implicit encode: JsonPickler.Writer[A]): backend.BValue = write(a)(encode)
+
+  val foosPico: backend.BValue = encodePico(foos)
+  val intsPico: backend.BValue = encodePico(ints)
+}
+
+trait PicopickleEncoding { self: ExampleData =>
+  @Benchmark
+  def encodeIntsPico: backend.BValue = encodePico(ints)
+
+  @Benchmark
+  def encodeFoosPico: backend.BValue = encodePico(foos)
+}
+
+trait PicopickleDecoding { self: ExampleData =>
+  @Benchmark
+  def decodeFoosPico: Map[String, Foo] = read[Map[String, Foo]](foosPico)
+
+  @Benchmark
+  def decodeIntsPico: List[Int] = read[List[Int]](intsPico)
+}
+
+trait PicopicklePrinting { self: ExampleData =>
+  @Benchmark
+  def printFoosPico: String = writeAst(foosPico)
+
+  @Benchmark
+  def printIntsPico: String = writeAst(intsPico)
+}
+
+trait PicopickleParsing { self: ExampleData =>
+  @Benchmark
+  def parseFoosPico: backend.BValue = readAst(foosJson)
+
+  @Benchmark
+  def parseIntsPico: backend.BValue = readAst(intsJson)
+}

--- a/src/main/scala-2.10/io/circe/benchmarks/PlayDefinitions.scala
+++ b/src/main/scala-2.10/io/circe/benchmarks/PlayDefinitions.scala
@@ -1,0 +1,8 @@
+package io.circe.benchmarks
+
+trait PlayFooInstances
+trait PlayData
+trait PlayEncoding
+trait PlayDecoding
+trait PlayPrinting
+trait PlayParsing

--- a/src/main/scala-2.11/io/circe/benchmarks/PicopickleDefinitions.scala
+++ b/src/main/scala-2.11/io/circe/benchmarks/PicopickleDefinitions.scala
@@ -1,0 +1,50 @@
+package io.circe.benchmarks
+
+import io.github.netvl.picopickle.backends.jawn.JsonPickler
+import io.github.netvl.picopickle.backends.jawn.JsonPickler._
+import org.openjdk.jmh.annotations._
+
+/**
+ * Note that this file appears in both the scala-2.10 and scala-2.11 source trees, and any changes
+ * should be reflected in both places.
+ */
+trait PicopickleFooInstances
+
+trait PicopickleData { self: ExampleData =>
+  @inline def encodePico[A](a: A)(implicit encode: JsonPickler.Writer[A]): backend.BValue = write(a)(encode)
+
+  val foosPico: backend.BValue = encodePico(foos)
+  val intsPico: backend.BValue = encodePico(ints)
+}
+
+trait PicopickleEncoding { self: ExampleData =>
+  @Benchmark
+  def encodeIntsPico: backend.BValue = encodePico(ints)
+
+  @Benchmark
+  def encodeFoosPico: backend.BValue = encodePico(foos)
+}
+
+trait PicopickleDecoding { self: ExampleData =>
+  @Benchmark
+  def decodeFoosPico: Map[String, Foo] = read[Map[String, Foo]](foosPico)
+
+  @Benchmark
+  def decodeIntsPico: List[Int] = read[List[Int]](intsPico)
+}
+
+trait PicopicklePrinting { self: ExampleData =>
+  @Benchmark
+  def printFoosPico: String = writeAst(foosPico)
+
+  @Benchmark
+  def printIntsPico: String = writeAst(intsPico)
+}
+
+trait PicopickleParsing { self: ExampleData =>
+  @Benchmark
+  def parseFoosPico: backend.BValue = readAst(foosJson)
+
+  @Benchmark
+  def parseIntsPico: backend.BValue = readAst(intsJson)
+}

--- a/src/main/scala-2.11/io/circe/benchmarks/PlayDefinitions.scala
+++ b/src/main/scala-2.11/io/circe/benchmarks/PlayDefinitions.scala
@@ -1,0 +1,58 @@
+package io.circe.benchmarks
+
+import org.openjdk.jmh.annotations._
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{ Format, JsPath, JsValue, Json, Writes }
+
+/**
+ * Note that this file appears in both the scala-2.11 and scala-2.12 source trees, and any changes
+ * should be reflected in both places.
+ */
+trait PlayFooInstances {
+  implicit val playFormatFoo: Format[Foo] = (
+    (JsPath \ "s").format[String] and
+    (JsPath \ "d").format[Double] and
+    (JsPath \ "i").format[Int] and
+    (JsPath \ "l").format[Long] and
+    (JsPath \ "bs").format[List[Boolean]]
+  )(Foo.apply, unlift(Foo.unapply))
+}
+
+trait PlayData { self: ExampleData =>
+  @inline def encodeP[A](a: A)(implicit encode: Writes[A]): JsValue = encode.writes(a)
+
+  val foosP: JsValue = encodeP(foos)
+  val intsP: JsValue = encodeP(ints)
+}
+
+trait PlayEncoding { self: ExampleData =>
+  @Benchmark
+  def encodeFoosP: JsValue = encodeP(foos)
+
+  @Benchmark
+  def encodeIntsP: JsValue = encodeP(ints)
+}
+
+trait PlayDecoding { self: ExampleData =>
+  @Benchmark
+  def decodeFoosP: Map[String, Foo] = foosP.as[Map[String, Foo]]
+
+  @Benchmark
+  def decodeIntsP: List[Int] = intsP.as[List[Int]]
+}
+
+trait PlayPrinting { self: ExampleData =>
+  @Benchmark
+  def printFoosP: String = Json.stringify(foosP)
+
+  @Benchmark
+  def printIntsP: String = Json.stringify(intsP)
+}
+
+trait PlayParsing { self: ExampleData =>
+  @Benchmark
+  def parseFoosP: JsValue = Json.parse(foosJson)
+
+  @Benchmark
+  def parseIntsP: JsValue = Json.parse(intsJson)
+}

--- a/src/main/scala-2.12/io/circe/benchmarks/PicopickleDefinitions.scala
+++ b/src/main/scala-2.12/io/circe/benchmarks/PicopickleDefinitions.scala
@@ -1,0 +1,8 @@
+package io.circe.benchmarks
+
+trait PicopickleFooInstances
+trait PicopickleData
+trait PicopickleEncoding
+trait PicopickleDecoding
+trait PicopicklePrinting
+trait PicopickleParsing

--- a/src/main/scala-2.12/io/circe/benchmarks/PlayDefinitions.scala
+++ b/src/main/scala-2.12/io/circe/benchmarks/PlayDefinitions.scala
@@ -1,0 +1,58 @@
+package io.circe.benchmarks
+
+import org.openjdk.jmh.annotations._
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{ Format, JsPath, JsValue, Json, Writes }
+
+/**
+ * Note that this file appears in both the scala-2.11 and scala-2.12 source trees, and any changes
+ * should be reflected in both places.
+ */
+trait PlayFooInstances {
+  implicit val playFormatFoo: Format[Foo] = (
+    (JsPath \ "s").format[String] and
+    (JsPath \ "d").format[Double] and
+    (JsPath \ "i").format[Int] and
+    (JsPath \ "l").format[Long] and
+    (JsPath \ "bs").format[List[Boolean]]
+  )(Foo.apply, unlift(Foo.unapply))
+}
+
+trait PlayData { self: ExampleData =>
+  @inline def encodeP[A](a: A)(implicit encode: Writes[A]): JsValue = encode.writes(a)
+
+  val foosP: JsValue = encodeP(foos)
+  val intsP: JsValue = encodeP(ints)
+}
+
+trait PlayEncoding { self: ExampleData =>
+  @Benchmark
+  def encodeFoosP: JsValue = encodeP(foos)
+
+  @Benchmark
+  def encodeIntsP: JsValue = encodeP(ints)
+}
+
+trait PlayDecoding { self: ExampleData =>
+  @Benchmark
+  def decodeFoosP: Map[String, Foo] = foosP.as[Map[String, Foo]]
+
+  @Benchmark
+  def decodeIntsP: List[Int] = intsP.as[List[Int]]
+}
+
+trait PlayPrinting { self: ExampleData =>
+  @Benchmark
+  def printFoosP: String = Json.stringify(foosP)
+
+  @Benchmark
+  def printIntsP: String = Json.stringify(intsP)
+}
+
+trait PlayParsing { self: ExampleData =>
+  @Benchmark
+  def parseFoosP: JsValue = Json.parse(foosJson)
+
+  @Benchmark
+  def parseIntsP: JsValue = Json.parse(intsJson)
+}

--- a/src/main/scala/io/circe/benchmarks/ArgonautDefinitions.scala
+++ b/src/main/scala/io/circe/benchmarks/ArgonautDefinitions.scala
@@ -1,0 +1,59 @@
+package io.circe.benchmarks
+
+import argonaut._, Argonaut._
+import org.openjdk.jmh.annotations._
+
+trait ArgonautFooInstances {
+  implicit val argonautCodecFoo: CodecJson[Foo] = CodecJson(
+    {
+      case Foo(s, d, i, l, bs) =>
+        ("s" := s) ->: ("d" := d) ->: ("i" := i) ->: ("l" := l) ->: ("bs" := bs) ->: jEmptyObject
+    },
+    c => for {
+      s  <- (c --\ "s").as[String]
+      d  <- (c --\ "d").as[Double]
+      i  <- (c --\ "i").as[Int]
+      l  <- (c --\ "l").as[Long]
+      bs <- (c --\ "bs").as[List[Boolean]]
+    } yield Foo(s, d, i, l, bs)
+  )
+}
+
+trait ArgonautData { self: ExampleData =>
+  @inline def encodeA[A](a: A)(implicit encode: EncodeJson[A]): Json = encode(a)
+
+  val foosA: Json = encodeA(foos)
+  val intsA: Json = encodeA(ints)
+}
+
+trait ArgonautEncoding { self: ExampleData =>
+  @Benchmark
+  def encodeFoosA: Json = encodeA(foos)
+
+  @Benchmark
+  def encodeIntsA: Json = encodeA(ints)
+}
+
+trait ArgonautDecoding { self: ExampleData =>
+  @Benchmark
+  def decodeFoosA: Map[String, Foo] = foosA.as[Map[String, Foo]].result.right.getOrElse(throw new Exception)
+
+  @Benchmark
+  def decodeIntsA: List[Int] = intsA.as[List[Int]].result.right.getOrElse(throw new Exception)
+}
+
+trait ArgonautPrinting { self: ExampleData =>
+  @Benchmark
+  def printFoosA: String = foosA.nospaces
+
+  @Benchmark
+  def printIntsA: String = intsA.nospaces
+}
+
+trait ArgonautParsing { self: ExampleData =>
+  @Benchmark
+  def parseFoosA: Json = Parse.parse(foosJson).right.getOrElse(throw new Exception)
+
+  @Benchmark
+  def parseIntsA: Json = Parse.parse(intsJson).right.getOrElse(throw new Exception)
+}

--- a/src/main/scala/io/circe/benchmarks/CirceDefinitions.scala
+++ b/src/main/scala/io/circe/benchmarks/CirceDefinitions.scala
@@ -1,0 +1,65 @@
+package io.circe.benchmarks
+
+import io.circe._, io.circe.jawn.parse, io.circe.syntax._
+import org.openjdk.jmh.annotations._
+
+trait CirceFooInstances {
+  implicit val circeEncodeFoo: Encoder[Foo] = new Encoder[Foo] {
+    def apply(foo: Foo): Json = Json.obj(
+      "s" -> foo.s.asJson,
+      "d" -> foo.d.asJson,
+      "i" -> foo.i.asJson,
+      "l" -> foo.l.asJson,
+      "bs" -> foo.bs.asJson
+    )
+  }
+
+  implicit val circeDecodeFoo: Decoder[Foo] = new Decoder[Foo] {
+    def apply(c: HCursor): Decoder.Result[Foo] = for {
+      s <- c.get[String]("s").right
+      d <- c.get[Double]("d").right
+      i <- c.get[Int]("i").right
+      l <- c.get[Long]("l").right
+      bs <- c.get[List[Boolean]]("bs").right
+    } yield Foo(s, d, i, l, bs)
+  }
+}
+
+trait CirceData { self: ExampleData =>
+  @inline def encodeC[A](a: A)(implicit encode: Encoder[A]): Json = encode(a)
+
+  val foosC: Json = encodeC(foos)
+  val intsC: Json = encodeC(ints)
+}
+
+trait CirceEncoding { self: ExampleData =>
+  @Benchmark
+  def encodeFoosC: Json = encodeC(foos)
+
+  @Benchmark
+  def encodeIntsC: Json = encodeC(ints)
+}
+
+trait CirceDecoding { self: ExampleData =>
+  @Benchmark
+  def decodeFoosC: Map[String, Foo] = foosC.as[Map[String, Foo]].right.getOrElse(throw new Exception)
+
+  @Benchmark
+  def decodeIntsC: List[Int] = intsC.as[List[Int]].right.getOrElse(throw new Exception)
+}
+
+trait CircePrinting { self: ExampleData =>
+  @Benchmark
+  def printFoosC: String = foosC.noSpaces
+
+  @Benchmark
+  def printIntsC: String = intsC.noSpaces
+}
+
+trait CirceParsing { self: ExampleData =>
+  @Benchmark
+  def parseFoosC: Json = parse(foosJson).right.getOrElse(throw new Exception)
+
+  @Benchmark
+  def parseIntsC: Json = parse(intsJson).right.getOrElse(throw new Exception)
+}

--- a/src/main/scala/io/circe/benchmarks/Foo.scala
+++ b/src/main/scala/io/circe/benchmarks/Foo.scala
@@ -1,0 +1,10 @@
+package io.circe.benchmarks
+
+import cats.kernel.Eq
+
+case class Foo(s: String, d: Double, i: Int, l: Long, bs: List[Boolean])
+
+object Foo extends ArgonautFooInstances with CirceFooInstances with SprayFooInstances
+    with PlayFooInstances with PicopickleFooInstances {
+  implicit val eqFoo: Eq[Foo] = Eq.fromUniversalEquals[Foo]
+}

--- a/src/main/scala/io/circe/benchmarks/SprayDefinitions.scala
+++ b/src/main/scala/io/circe/benchmarks/SprayDefinitions.scala
@@ -1,0 +1,62 @@
+package io.circe.benchmarks
+
+import org.openjdk.jmh.annotations._
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+trait SprayFooInstances {
+  implicit val sprayFormatFoo: RootJsonFormat[Foo] = new RootJsonFormat[Foo] {
+    def write(foo: Foo): JsObject = JsObject(
+      "s" -> foo.s.toJson,
+      "d" -> foo.d.toJson,
+      "i" -> foo.i.toJson,
+      "l" -> foo.l.toJson,
+      "bs" -> foo.bs.toJson
+    )
+
+    def read(value: JsValue): Foo = value.asJsObject.getFields("s", "d", "i", "l", "bs") match {
+      case Seq(JsString(s), d, i, l, bs) =>
+        Foo(s, d.convertTo[Double], i.convertTo[Int], l.convertTo[Long], bs.convertTo[List[Boolean]])
+      case _ => throw new DeserializationException("Foo expected")
+    }
+  }
+}
+
+trait SprayData { self: ExampleData =>
+  @inline def encodeS[A](a: A)(implicit encode: JsonWriter[A]): JsValue = encode.write(a)
+
+  val foosS: JsValue = encodeS(foos)
+  val intsS: JsValue = encodeS(ints)
+}
+
+trait SprayEncoding { self: ExampleData =>
+  @Benchmark
+  def encodeFoosS: JsValue = encodeS(foos)
+
+  @Benchmark
+  def encodeIntsS: JsValue = encodeS(ints)
+}
+
+trait SprayDecoding { self: ExampleData =>
+  @Benchmark
+  def decodeFoosS: Map[String, Foo] = foosS.convertTo[Map[String, Foo]]
+
+  @Benchmark
+  def decodeIntsS: List[Int] = intsS.convertTo[List[Int]]
+}
+
+trait SprayPrinting { self: ExampleData =>
+  @Benchmark
+  def printFoosS: String = foosS.compactPrint
+
+  @Benchmark
+  def printIntsS: String = intsS.compactPrint
+}
+
+trait SprayParsing { self: ExampleData =>
+  @Benchmark
+  def parseFoosS: JsValue = JsonParser(foosJson)
+
+  @Benchmark
+  def parseIntsS: JsValue = JsonParser(intsJson)
+}

--- a/src/test/scala-2.10/io/circe/benchmarks/VersionSpecificSpecs.scala
+++ b/src/test/scala-2.10/io/circe/benchmarks/VersionSpecificSpecs.scala
@@ -1,0 +1,51 @@
+package io.circe.benchmarks
+
+import io.github.netvl.picopickle.backends.jawn.JsonPickler._
+
+trait VersionSpecificDecodingSpec { self: DecodingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.10 decoding benchmark" should "correctly decode integers using Picopickle" in {
+    assert(decodeIntsPico === ints)
+  }
+
+  it should "correctly decode case classes using Picopickle" in {
+    assert(decodeFoosPico === foos)
+  }
+}
+
+trait VersionSpecificEncodingSpec { self: EncodingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.10 encoding benchmark" should "correctly encode integers using Picopickle" in {
+    assert(self.decodeInts(writeAst(encodeIntsPico)) === Some(ints))
+  }
+
+  it should "correctly encode case classes using Picopickle" in {
+    assert(self.decodeFoos(writeAst(encodeFoosPico)) === Some(foos))
+  }
+}
+
+trait VersionSpecificParsingSpec { self: ParsingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.10 parsing benchmark" should "correctly parse integers using Picopickle" in {
+    assert(parseIntsPico === intsPico)
+  }
+
+  it should "correctly parse case classes using Picopickle" in {
+    assert(parseFoosPico === foosPico)
+  }
+}
+
+trait VersionSpecificPrintingSpec { self: PrintingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.10 printing benchmark" should "correctly print integers using Picopickle" in {
+    assert(self.decodeInts(printIntsPico) === Some(ints))
+  }
+  
+  it should "correctly print case classes using Picopickle" in {
+    assert(self.decodeFoos(printFoosPico) === Some(foos))
+  }
+}

--- a/src/test/scala-2.11/io/circe/benchmarks/VersionSpecificSpecs.scala
+++ b/src/test/scala-2.11/io/circe/benchmarks/VersionSpecificSpecs.scala
@@ -1,0 +1,84 @@
+package io.circe.benchmarks
+
+import io.github.netvl.picopickle.backends.jawn.JsonPickler._
+import play.api.libs.json.Json
+
+trait VersionSpecificDecodingSpec { self: DecodingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.11 decoding benchmark" should "correctly decode integers using Picopickle" in {
+    assert(decodeIntsPico === ints)
+  }
+
+  it should "correctly decode integers using Play JSON" in {
+    assert(decodeIntsP === ints)
+  }
+
+  it should "correctly decode case classes using Picopickle" in {
+    assert(decodeFoosPico === foos)
+  }
+
+  it should "correctly decode case classes using Play JSON" in {
+    assert(decodeFoosP === foos)
+  }
+}
+
+trait VersionSpecificEncodingSpec { self: EncodingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.11 encoding benchmark" should "correctly encode integers using Picopickle" in {
+    assert(self.decodeInts(writeAst(encodeIntsPico)) === Some(ints))
+  }
+
+  it should "correctly encode integers using Play JSON" in {
+    assert(self.decodeInts(Json.prettyPrint(encodeIntsP)) === Some(ints))
+  }
+
+  it should "correctly encode case classes using Picopickle" in {
+    assert(self.decodeFoos(writeAst(encodeFoosPico)) === Some(foos))
+  }
+
+  it should "correctly encode case classes using Play JSON" in {
+    assert(self.decodeFoos(Json.prettyPrint(encodeFoosP)) === Some(foos))
+  }
+}
+
+trait VersionSpecificParsingSpec { self: ParsingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.11 parsing benchmark" should "correctly parse integers using Picopickle" in {
+    assert(parseIntsPico === intsPico)
+  }
+
+  it should "correctly parse integers using Play JSON" in {
+    assert(parseIntsP === intsP)
+  }
+
+  it should "correctly parse case classes using Picopickle" in {
+    assert(parseFoosPico === foosPico)
+  }
+
+  it should "correctly parse case classes using Play JSON" in {
+    assert(parseFoosP === foosP)
+  }
+}
+
+trait VersionSpecificPrintingSpec { self: PrintingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.11 printing benchmark" should "correctly print integers using Picopickle" in {
+    assert(self.decodeInts(printIntsPico) === Some(ints))
+  }
+
+  it should "correctly print integers using Play JSON" in {
+    assert(self.decodeInts(printIntsP) === Some(ints))
+  }
+  
+  it should "correctly print case classes using Picopickle" in {
+    assert(self.decodeFoos(printFoosPico) === Some(foos))
+  }
+
+  it should "correctly print case classes using Play JSON" in {
+    assert(self.decodeFoos(printFoosP) === Some(foos))
+  }
+}

--- a/src/test/scala-2.12/io/circe/benchmarks/VersionSpecificSpecs.scala
+++ b/src/test/scala-2.12/io/circe/benchmarks/VersionSpecificSpecs.scala
@@ -1,0 +1,51 @@
+package io.circe.benchmarks
+
+import play.api.libs.json.Json
+
+trait VersionSpecificDecodingSpec { self: DecodingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.12 decoding benchmark" should "correctly decode integers using Play JSON" in {
+    assert(decodeIntsP === ints)
+  }
+
+  it should "correctly decode case classes using Play JSON" in {
+    assert(decodeFoosP === foos)
+  }
+}
+
+trait VersionSpecificEncodingSpec { self: EncodingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.12 encoding benchmark" should "correctly encode integers using Play JSON" in {
+    assert(self.decodeInts(Json.prettyPrint(encodeIntsP)) === Some(ints))
+  }
+
+  it should "correctly encode case classes using Play JSON" in {
+    assert(self.decodeFoos(Json.prettyPrint(encodeFoosP)) === Some(foos))
+  }
+}
+
+trait VersionSpecificParsingSpec { self: ParsingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.12 parsing benchmark" should "correctly parse integers using Play JSON" in {
+    assert(parseIntsP === intsP)
+  }
+
+  it should "correctly parse case classes using Play JSON" in {
+    assert(parseFoosP === foosP)
+  }
+}
+
+trait VersionSpecificPrintingSpec { self: PrintingBenchmarkSpec =>
+  import benchmark._
+
+  "The 2.12 printing benchmark" should "correctly print integers using Play JSON" in {
+    assert(self.decodeInts(printIntsP) === Some(ints))
+  }
+
+  it should "correctly print case classes using Play JSON" in {
+    assert(self.decodeFoos(printFoosP) === Some(foos))
+  }
+}

--- a/src/test/scala/io/circe/benchmarks/DecodingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/DecodingBenchmarkSpec.scala
@@ -2,7 +2,7 @@ package io.circe.benchmarks
 
 import org.scalatest.FlatSpec
 
-class DecodingBenchmarkSpec extends FlatSpec {
+class DecodingBenchmarkSpec extends FlatSpec with VersionSpecificDecodingSpec {
   val benchmark: DecodingBenchmark = new DecodingBenchmark
 
   import benchmark._
@@ -15,16 +15,8 @@ class DecodingBenchmarkSpec extends FlatSpec {
     assert(decodeIntsA === ints)
   }
 
-  it should "correctly decode integers using Play JSON" in {
-    assert(decodeIntsP === ints)
-  }
-
   it should "correctly decode integers using Spray JSON" in {
     assert(decodeIntsS === ints)
-  }
-
-  it should "correctly decode integers using Picopickle" in {
-    assert(decodeIntsPico === ints)
   }
 
   it should "correctly decode case classes using Circe" in {
@@ -35,15 +27,7 @@ class DecodingBenchmarkSpec extends FlatSpec {
     assert(decodeFoosA === foos)
   }
 
-  it should "correctly decode case classes using Play JSON" in {
-    assert(decodeFoosP === foos)
-  }
-
   it should "correctly decode case classes using Spray JSON" in {
     assert(decodeFoosS === foos)
-  }
-
-  it should "correctly decode case classes using Picopickle" in {
-    assert(decodeFoosPico === foos)
   }
 }

--- a/src/test/scala/io/circe/benchmarks/EncodingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/EncodingBenchmarkSpec.scala
@@ -2,18 +2,16 @@ package io.circe.benchmarks
 
 import argonaut.Parse, argonaut.Argonaut._
 import org.scalatest.FlatSpec
-import play.api.libs.json.{ Json => JsonP }
-import io.github.netvl.picopickle.backends.jawn.JsonPickler._
 
-class EncodingBenchmarkSpec extends FlatSpec {
+class EncodingBenchmarkSpec extends FlatSpec with VersionSpecificEncodingSpec {
   val benchmark: EncodingBenchmark = new EncodingBenchmark
 
   import benchmark._
 
-  private[this] def decodeInts(json: String): Option[List[Int]] =
+  def decodeInts(json: String): Option[List[Int]] =
     Parse.decodeOption[List[Int]](json)
 
-  private[this] def decodeFoos(json: String): Option[Map[String, Foo]] =
+  def decodeFoos(json: String): Option[Map[String, Foo]] =
     Parse.decodeOption[Map[String, Foo]](json)
 
   "The encoding benchmark" should "correctly encode integers using Circe" in {
@@ -24,16 +22,8 @@ class EncodingBenchmarkSpec extends FlatSpec {
     assert(decodeInts(encodeIntsA.nospaces) === Some(ints))
   }
 
-  it should "correctly encode integers using Play JSON" in {
-    assert(decodeInts(JsonP.prettyPrint(encodeIntsP)) === Some(ints))
-  }
-
   it should "correctly encode integers using Spray JSON" in {
     assert(decodeInts(encodeIntsS.compactPrint) === Some(ints))
-  }
-
-  it should "correctly encode integers using Picopickle" in {
-    assert(decodeInts(writeAst(encodeIntsPico)) === Some(ints))
   }
 
   it should "correctly encode case classes using Circe" in {
@@ -44,15 +34,7 @@ class EncodingBenchmarkSpec extends FlatSpec {
     assert(decodeFoos(encodeFoosA.nospaces) === Some(foos))
   }
 
-  it should "correctly encode case classes using Play JSON" in {
-    assert(decodeFoos(JsonP.prettyPrint(encodeFoosP)) === Some(foos))
-  }
-
   it should "correctly encode case classes using Spray JSON" in {
     assert(decodeFoos(encodeFoosS.compactPrint) === Some(foos))
-  }
-
-  it should "correctly encode case classes using Picopickle" in {
-    assert(decodeFoos(writeAst(encodeFoosPico)) === Some(foos))
   }
 }

--- a/src/test/scala/io/circe/benchmarks/ParsingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/ParsingBenchmarkSpec.scala
@@ -2,7 +2,7 @@ package io.circe.benchmarks
 
 import org.scalatest.FlatSpec
 
-class ParsingBenchmarkSpec extends FlatSpec {
+class ParsingBenchmarkSpec extends FlatSpec with VersionSpecificParsingSpec {
   val benchmark: ParsingBenchmark = new ParsingBenchmark
 
   import benchmark._
@@ -15,16 +15,8 @@ class ParsingBenchmarkSpec extends FlatSpec {
     assert(parseIntsA === intsA)
   }
 
-  it should "correctly parse integers using Play JSON" in {
-    assert(parseIntsP === intsP)
-  }
-
   it should "correctly parse integers using Spray JSON" in {
     assert(parseIntsS === intsS)
-  }
-
-  it should "correctly parse integers using Picopickle" in {
-    assert(parseIntsPico === intsPico)
   }
 
   it should "correctly parse case classes using Circe" in {
@@ -35,15 +27,7 @@ class ParsingBenchmarkSpec extends FlatSpec {
     assert(parseFoosA === foosA)
   }
 
-  it should "correctly parse case classes using Play JSON" in {
-    assert(parseFoosP === foosP)
-  }
-
   it should "correctly parse case classes using Spray JSON" in {
     assert(parseFoosS === foosS)
-  }
-
-  it should "correctly parse case classes using Picopickle" in {
-    assert(parseFoosPico === foosPico)
   }
 }

--- a/src/test/scala/io/circe/benchmarks/PrintingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/PrintingBenchmarkSpec.scala
@@ -3,15 +3,15 @@ package io.circe.benchmarks
 import argonaut.Parse, argonaut.Argonaut._
 import org.scalatest.FlatSpec
 
-class PrintingBenchmarkSpec extends FlatSpec {
+class PrintingBenchmarkSpec extends FlatSpec with VersionSpecificPrintingSpec {
   val benchmark: PrintingBenchmark = new PrintingBenchmark
 
   import benchmark._
 
-  private[this] def decodeInts(json: String): Option[List[Int]] =
+  def decodeInts(json: String): Option[List[Int]] =
     Parse.decodeOption[List[Int]](json)
 
-  private[this] def decodeFoos(json: String): Option[Map[String, Foo]] =
+  def decodeFoos(json: String): Option[Map[String, Foo]] =
     Parse.decodeOption[Map[String, Foo]](json)
 
   "The printing benchmark" should "correctly print integers using Circe" in {
@@ -22,16 +22,8 @@ class PrintingBenchmarkSpec extends FlatSpec {
     assert(decodeInts(printIntsA) === Some(ints))
   }
 
-  it should "correctly print integers using Play JSON" in {
-    assert(decodeInts(printIntsP) === Some(ints))
-  }
-
   it should "correctly print integers using Spray JSON" in {
     assert(decodeInts(printIntsS) === Some(ints))
-  }
-
-  it should "correctly print integers using Picopickle" in {
-    assert(decodeInts(printIntsPico) === Some(ints))
   }
 
   it should "correctly print case classes using Circe" in {
@@ -42,15 +34,7 @@ class PrintingBenchmarkSpec extends FlatSpec {
     assert(decodeFoos(printFoosA) === Some(foos))
   }
 
-  it should "correctly print case classes using Play JSON" in {
-    assert(decodeFoos(printFoosP) === Some(foos))
-  }
-
   it should "correctly print case classes using Spray JSON" in {
     assert(decodeFoos(printFoosS) === Some(foos))
-  }
-
-  it should "correctly print case classes using Picopickle" in {
-    assert(decodeFoos(printFoosPico) === Some(foos))
   }
 }


### PR DESCRIPTION
This change makes it possible to run benchmarks for 2.10, 2.11, and 2.12.

Libraries such as Play and Picopickle that are not published for all three versions must be added to version-specific source trees.

I've also removed JDK 7 from the Travis CI config, since the latest version of Play is published for 2.11 but requires Java 8.