### PR TITLE
Expand names of benchmark methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,31 +25,31 @@ Spray. The `Foos` benchmarks measure encoding and decoding a relatively complex 
 members, while the `Ints` benchmarks work with a list of integers.
 
 ```
-Benchmark                          Mode  Cnt      Score      Error  Units
-DecodingBenchmark.decodeFoosC     thrpt  100  10161.304 ±  102.923  ops/s
-DecodingBenchmark.decodeFoosA     thrpt  100   2786.826 ±   43.675  ops/s
-DecodingBenchmark.decodeFoosP     thrpt  100   1974.245 ±    9.858  ops/s
-DecodingBenchmark.decodeFoosPico  thrpt  100   2106.936 ±   31.172  ops/s
-DecodingBenchmark.decodeFoosS     thrpt  100   8193.956 ±   38.757  ops/s
+Benchmark                                Mode  Cnt      Score      Error  Units
+DecodingBenchmark.decodeFoosCirce       thrpt  100  10161.304 ±  102.923  ops/s
+DecodingBenchmark.decodeFoosArgonaut    thrpt  100   2786.826 ±   43.675  ops/s
+DecodingBenchmark.decodeFoosPlay        thrpt  100   1974.245 ±    9.858  ops/s
+DecodingBenchmark.decodeFoosPico        thrpt  100   2106.936 ±   31.172  ops/s
+DecodingBenchmark.decodeFoosSpray       thrpt  100   8193.956 ±   38.757  ops/s
 
-DecodingBenchmark.decodeIntsC     thrpt  100  50399.910 ±  156.052  ops/s
-DecodingBenchmark.decodeIntsA     thrpt  100  20472.141 ±  412.459  ops/s
-DecodingBenchmark.decodeIntsP     thrpt  100  15146.795 ±   68.217  ops/s
-DecodingBenchmark.decodeIntsPico  thrpt  100  15760.650 ±  972.880  ops/s
-DecodingBenchmark.decodeIntsS     thrpt  100  81535.344 ±  293.525  ops/s
+DecodingBenchmark.decodeIntsCirce       thrpt  100  50399.910 ±  156.052  ops/s
+DecodingBenchmark.decodeIntsArgonaut    thrpt  100  20472.141 ±  412.459  ops/s
+DecodingBenchmark.decodeIntsPlay        thrpt  100  15146.795 ±   68.217  ops/s
+DecodingBenchmark.decodeIntsPico        thrpt  100  15760.650 ±  972.880  ops/s
+DecodingBenchmark.decodeIntsSpray       thrpt  100  81535.344 ±  293.525  ops/s
 
-Benchmark                          Mode  Cnt      Score      Error  Units
-EncodingBenchmark.encodeFoosC     thrpt  100   8565.560 ±  107.385  ops/s
-EncodingBenchmark.encodeFoosA     thrpt  100   6736.379 ±   15.906  ops/s
-EncodingBenchmark.encodeFoosP     thrpt  100   1765.981 ±    4.078  ops/s
-EncodingBenchmark.encodeFoosPico  thrpt  100   5779.484 ±   26.803  ops/s
-EncodingBenchmark.encodeFoosS     thrpt  100   6561.330 ±   29.160  ops/s
+Benchmark                                Mode  Cnt      Score      Error  Units
+EncodingBenchmark.encodeFoosCirce       thrpt  100   8565.560 ±  107.385  ops/s
+EncodingBenchmark.encodeFoosArgonaut    thrpt  100   6736.379 ±   15.906  ops/s
+EncodingBenchmark.encodeFoosPlay        thrpt  100   1765.981 ±    4.078  ops/s
+EncodingBenchmark.encodeFoosPico        thrpt  100   5779.484 ±   26.803  ops/s
+EncodingBenchmark.encodeFoosSpray       thrpt  100   6561.330 ±   29.160  ops/s
 
-EncodingBenchmark.encodeIntsC     thrpt  100  98093.604 ±  223.612  ops/s
-EncodingBenchmark.encodeIntsA     thrpt  100  80580.759 ±  323.298  ops/s
-EncodingBenchmark.encodeIntsP     thrpt  100  29823.703 ±  451.211  ops/s
-EncodingBenchmark.encodeIntsPico  thrpt  100  37110.701 ±  145.859  ops/s
-EncodingBenchmark.encodeIntsS     thrpt  100  43733.808 ± 2810.698  ops/s
+EncodingBenchmark.encodeIntsCirce       thrpt  100  98093.604 ±  223.612  ops/s
+EncodingBenchmark.encodeIntsArgonaut    thrpt  100  80580.759 ±  323.298  ops/s
+EncodingBenchmark.encodeIntsPlay        thrpt  100  29823.703 ±  451.211  ops/s
+EncodingBenchmark.encodeIntsPico        thrpt  100  37110.701 ±  145.859  ops/s
+EncodingBenchmark.encodeIntsSpray       thrpt  100  43733.808 ± 2810.698  ops/s
 ```
 
 (Please see the commands above for the parsing and printing benchmarks.)

--- a/src/main/scala-2.11/io/circe/benchmarks/PlayDefinitions.scala
+++ b/src/main/scala-2.11/io/circe/benchmarks/PlayDefinitions.scala
@@ -27,32 +27,32 @@ trait PlayData { self: ExampleData =>
 
 trait PlayEncoding { self: ExampleData =>
   @Benchmark
-  def encodeFoosP: JsValue = encodeP(foos)
+  def encodeFoosPlay: JsValue = encodeP(foos)
 
   @Benchmark
-  def encodeIntsP: JsValue = encodeP(ints)
+  def encodeIntsPlay: JsValue = encodeP(ints)
 }
 
 trait PlayDecoding { self: ExampleData =>
   @Benchmark
-  def decodeFoosP: Map[String, Foo] = foosP.as[Map[String, Foo]]
+  def decodeFoosPlay: Map[String, Foo] = foosP.as[Map[String, Foo]]
 
   @Benchmark
-  def decodeIntsP: List[Int] = intsP.as[List[Int]]
+  def decodeIntsPlay: List[Int] = intsP.as[List[Int]]
 }
 
 trait PlayPrinting { self: ExampleData =>
   @Benchmark
-  def printFoosP: String = Json.stringify(foosP)
+  def printFoosPlay: String = Json.stringify(foosP)
 
   @Benchmark
-  def printIntsP: String = Json.stringify(intsP)
+  def printIntsPlay: String = Json.stringify(intsP)
 }
 
 trait PlayParsing { self: ExampleData =>
   @Benchmark
-  def parseFoosP: JsValue = Json.parse(foosJson)
+  def parseFoosPlay: JsValue = Json.parse(foosJson)
 
   @Benchmark
-  def parseIntsP: JsValue = Json.parse(intsJson)
+  def parseIntsPlay: JsValue = Json.parse(intsJson)
 }

--- a/src/main/scala-2.12/io/circe/benchmarks/PlayDefinitions.scala
+++ b/src/main/scala-2.12/io/circe/benchmarks/PlayDefinitions.scala
@@ -27,32 +27,32 @@ trait PlayData { self: ExampleData =>
 
 trait PlayEncoding { self: ExampleData =>
   @Benchmark
-  def encodeFoosP: JsValue = encodeP(foos)
+  def encodeFoosPlay: JsValue = encodeP(foos)
 
   @Benchmark
-  def encodeIntsP: JsValue = encodeP(ints)
+  def encodeIntsPlay: JsValue = encodeP(ints)
 }
 
 trait PlayDecoding { self: ExampleData =>
   @Benchmark
-  def decodeFoosP: Map[String, Foo] = foosP.as[Map[String, Foo]]
+  def decodeFoosPlay: Map[String, Foo] = foosP.as[Map[String, Foo]]
 
   @Benchmark
-  def decodeIntsP: List[Int] = intsP.as[List[Int]]
+  def decodeIntsPlay: List[Int] = intsP.as[List[Int]]
 }
 
 trait PlayPrinting { self: ExampleData =>
   @Benchmark
-  def printFoosP: String = Json.stringify(foosP)
+  def printFoosPlay: String = Json.stringify(foosP)
 
   @Benchmark
-  def printIntsP: String = Json.stringify(intsP)
+  def printIntsPlay: String = Json.stringify(intsP)
 }
 
 trait PlayParsing { self: ExampleData =>
   @Benchmark
-  def parseFoosP: JsValue = Json.parse(foosJson)
+  def parseFoosPlay: JsValue = Json.parse(foosJson)
 
   @Benchmark
-  def parseIntsP: JsValue = Json.parse(intsJson)
+  def parseIntsPlay: JsValue = Json.parse(intsJson)
 }

--- a/src/main/scala/io/circe/benchmarks/ArgonautDefinitions.scala
+++ b/src/main/scala/io/circe/benchmarks/ArgonautDefinitions.scala
@@ -28,32 +28,32 @@ trait ArgonautData { self: ExampleData =>
 
 trait ArgonautEncoding { self: ExampleData =>
   @Benchmark
-  def encodeFoosA: Json = encodeA(foos)
+  def encodeFoosArgonaut: Json = encodeA(foos)
 
   @Benchmark
-  def encodeIntsA: Json = encodeA(ints)
+  def encodeIntsArgonaut: Json = encodeA(ints)
 }
 
 trait ArgonautDecoding { self: ExampleData =>
   @Benchmark
-  def decodeFoosA: Map[String, Foo] = foosA.as[Map[String, Foo]].result.right.getOrElse(throw new Exception)
+  def decodeFoosArgonaut: Map[String, Foo] = foosA.as[Map[String, Foo]].result.right.getOrElse(throw new Exception)
 
   @Benchmark
-  def decodeIntsA: List[Int] = intsA.as[List[Int]].result.right.getOrElse(throw new Exception)
+  def decodeIntsArgonaut: List[Int] = intsA.as[List[Int]].result.right.getOrElse(throw new Exception)
 }
 
 trait ArgonautPrinting { self: ExampleData =>
   @Benchmark
-  def printFoosA: String = foosA.nospaces
+  def printFoosArgonaut: String = foosA.nospaces
 
   @Benchmark
-  def printIntsA: String = intsA.nospaces
+  def printIntsArgonaut: String = intsA.nospaces
 }
 
 trait ArgonautParsing { self: ExampleData =>
   @Benchmark
-  def parseFoosA: Json = Parse.parse(foosJson).right.getOrElse(throw new Exception)
+  def parseFoosArgonaut: Json = Parse.parse(foosJson).right.getOrElse(throw new Exception)
 
   @Benchmark
-  def parseIntsA: Json = Parse.parse(intsJson).right.getOrElse(throw new Exception)
+  def parseIntsArgonaut: Json = Parse.parse(intsJson).right.getOrElse(throw new Exception)
 }

--- a/src/main/scala/io/circe/benchmarks/CirceDefinitions.scala
+++ b/src/main/scala/io/circe/benchmarks/CirceDefinitions.scala
@@ -34,32 +34,32 @@ trait CirceData { self: ExampleData =>
 
 trait CirceEncoding { self: ExampleData =>
   @Benchmark
-  def encodeFoosC: Json = encodeC(foos)
+  def encodeFoosCirce: Json = encodeC(foos)
 
   @Benchmark
-  def encodeIntsC: Json = encodeC(ints)
+  def encodeIntsCirce: Json = encodeC(ints)
 }
 
 trait CirceDecoding { self: ExampleData =>
   @Benchmark
-  def decodeFoosC: Map[String, Foo] = foosC.as[Map[String, Foo]].right.getOrElse(throw new Exception)
+  def decodeFoosCirce: Map[String, Foo] = foosC.as[Map[String, Foo]].right.getOrElse(throw new Exception)
 
   @Benchmark
-  def decodeIntsC: List[Int] = intsC.as[List[Int]].right.getOrElse(throw new Exception)
+  def decodeIntsCirce: List[Int] = intsC.as[List[Int]].right.getOrElse(throw new Exception)
 }
 
 trait CircePrinting { self: ExampleData =>
   @Benchmark
-  def printFoosC: String = foosC.noSpaces
+  def printFoosCirce: String = foosC.noSpaces
 
   @Benchmark
-  def printIntsC: String = intsC.noSpaces
+  def printIntsCirce: String = intsC.noSpaces
 }
 
 trait CirceParsing { self: ExampleData =>
   @Benchmark
-  def parseFoosC: Json = parse(foosJson).right.getOrElse(throw new Exception)
+  def parseFoosCirce: Json = parse(foosJson).right.getOrElse(throw new Exception)
 
   @Benchmark
-  def parseIntsC: Json = parse(intsJson).right.getOrElse(throw new Exception)
+  def parseIntsCirce: Json = parse(intsJson).right.getOrElse(throw new Exception)
 }

--- a/src/main/scala/io/circe/benchmarks/SprayDefinitions.scala
+++ b/src/main/scala/io/circe/benchmarks/SprayDefinitions.scala
@@ -31,32 +31,32 @@ trait SprayData { self: ExampleData =>
 
 trait SprayEncoding { self: ExampleData =>
   @Benchmark
-  def encodeFoosS: JsValue = encodeS(foos)
+  def encodeFoosSpray: JsValue = encodeS(foos)
 
   @Benchmark
-  def encodeIntsS: JsValue = encodeS(ints)
+  def encodeIntsSpray: JsValue = encodeS(ints)
 }
 
 trait SprayDecoding { self: ExampleData =>
   @Benchmark
-  def decodeFoosS: Map[String, Foo] = foosS.convertTo[Map[String, Foo]]
+  def decodeFoosSpray: Map[String, Foo] = foosS.convertTo[Map[String, Foo]]
 
   @Benchmark
-  def decodeIntsS: List[Int] = intsS.convertTo[List[Int]]
+  def decodeIntsSpray: List[Int] = intsS.convertTo[List[Int]]
 }
 
 trait SprayPrinting { self: ExampleData =>
   @Benchmark
-  def printFoosS: String = foosS.compactPrint
+  def printFoosSpray: String = foosS.compactPrint
 
   @Benchmark
-  def printIntsS: String = intsS.compactPrint
+  def printIntsSpray: String = intsS.compactPrint
 }
 
 trait SprayParsing { self: ExampleData =>
   @Benchmark
-  def parseFoosS: JsValue = JsonParser(foosJson)
+  def parseFoosSpray: JsValue = JsonParser(foosJson)
 
   @Benchmark
-  def parseIntsS: JsValue = JsonParser(intsJson)
+  def parseIntsSpray: JsValue = JsonParser(intsJson)
 }

--- a/src/test/scala-2.11/io/circe/benchmarks/VersionSpecificSpecs.scala
+++ b/src/test/scala-2.11/io/circe/benchmarks/VersionSpecificSpecs.scala
@@ -11,7 +11,7 @@ trait VersionSpecificDecodingSpec { self: DecodingBenchmarkSpec =>
   }
 
   it should "correctly decode integers using Play JSON" in {
-    assert(decodeIntsP === ints)
+    assert(decodeIntsPlay === ints)
   }
 
   it should "correctly decode case classes using Picopickle" in {
@@ -19,7 +19,7 @@ trait VersionSpecificDecodingSpec { self: DecodingBenchmarkSpec =>
   }
 
   it should "correctly decode case classes using Play JSON" in {
-    assert(decodeFoosP === foos)
+    assert(decodeFoosPlay === foos)
   }
 }
 
@@ -31,7 +31,7 @@ trait VersionSpecificEncodingSpec { self: EncodingBenchmarkSpec =>
   }
 
   it should "correctly encode integers using Play JSON" in {
-    assert(self.decodeInts(Json.prettyPrint(encodeIntsP)) === Some(ints))
+    assert(self.decodeInts(Json.prettyPrint(encodeIntsPlay)) === Some(ints))
   }
 
   it should "correctly encode case classes using Picopickle" in {
@@ -39,7 +39,7 @@ trait VersionSpecificEncodingSpec { self: EncodingBenchmarkSpec =>
   }
 
   it should "correctly encode case classes using Play JSON" in {
-    assert(self.decodeFoos(Json.prettyPrint(encodeFoosP)) === Some(foos))
+    assert(self.decodeFoos(Json.prettyPrint(encodeFoosPlay)) === Some(foos))
   }
 }
 
@@ -51,7 +51,7 @@ trait VersionSpecificParsingSpec { self: ParsingBenchmarkSpec =>
   }
 
   it should "correctly parse integers using Play JSON" in {
-    assert(parseIntsP === intsP)
+    assert(parseIntsPlay === intsP)
   }
 
   it should "correctly parse case classes using Picopickle" in {
@@ -59,7 +59,7 @@ trait VersionSpecificParsingSpec { self: ParsingBenchmarkSpec =>
   }
 
   it should "correctly parse case classes using Play JSON" in {
-    assert(parseFoosP === foosP)
+    assert(parseFoosPlay === foosP)
   }
 }
 
@@ -71,7 +71,7 @@ trait VersionSpecificPrintingSpec { self: PrintingBenchmarkSpec =>
   }
 
   it should "correctly print integers using Play JSON" in {
-    assert(self.decodeInts(printIntsP) === Some(ints))
+    assert(self.decodeInts(printIntsPlay) === Some(ints))
   }
   
   it should "correctly print case classes using Picopickle" in {
@@ -79,6 +79,6 @@ trait VersionSpecificPrintingSpec { self: PrintingBenchmarkSpec =>
   }
 
   it should "correctly print case classes using Play JSON" in {
-    assert(self.decodeFoos(printFoosP) === Some(foos))
+    assert(self.decodeFoos(printFoosPlay) === Some(foos))
   }
 }

--- a/src/test/scala-2.12/io/circe/benchmarks/VersionSpecificSpecs.scala
+++ b/src/test/scala-2.12/io/circe/benchmarks/VersionSpecificSpecs.scala
@@ -6,11 +6,11 @@ trait VersionSpecificDecodingSpec { self: DecodingBenchmarkSpec =>
   import benchmark._
 
   "The 2.12 decoding benchmark" should "correctly decode integers using Play JSON" in {
-    assert(decodeIntsP === ints)
+    assert(decodeIntsPlay === ints)
   }
 
   it should "correctly decode case classes using Play JSON" in {
-    assert(decodeFoosP === foos)
+    assert(decodeFoosPlay === foos)
   }
 }
 
@@ -18,11 +18,11 @@ trait VersionSpecificEncodingSpec { self: EncodingBenchmarkSpec =>
   import benchmark._
 
   "The 2.12 encoding benchmark" should "correctly encode integers using Play JSON" in {
-    assert(self.decodeInts(Json.prettyPrint(encodeIntsP)) === Some(ints))
+    assert(self.decodeInts(Json.prettyPrint(encodeIntsPlay)) === Some(ints))
   }
 
   it should "correctly encode case classes using Play JSON" in {
-    assert(self.decodeFoos(Json.prettyPrint(encodeFoosP)) === Some(foos))
+    assert(self.decodeFoos(Json.prettyPrint(encodeFoosPlay)) === Some(foos))
   }
 }
 
@@ -30,11 +30,11 @@ trait VersionSpecificParsingSpec { self: ParsingBenchmarkSpec =>
   import benchmark._
 
   "The 2.12 parsing benchmark" should "correctly parse integers using Play JSON" in {
-    assert(parseIntsP === intsP)
+    assert(parseIntsPlay === intsP)
   }
 
   it should "correctly parse case classes using Play JSON" in {
-    assert(parseFoosP === foosP)
+    assert(parseFoosPlay === foosP)
   }
 }
 
@@ -42,10 +42,10 @@ trait VersionSpecificPrintingSpec { self: PrintingBenchmarkSpec =>
   import benchmark._
 
   "The 2.12 printing benchmark" should "correctly print integers using Play JSON" in {
-    assert(self.decodeInts(printIntsP) === Some(ints))
+    assert(self.decodeInts(printIntsPlay) === Some(ints))
   }
 
   it should "correctly print case classes using Play JSON" in {
-    assert(self.decodeFoos(printFoosP) === Some(foos))
+    assert(self.decodeFoos(printFoosPlay) === Some(foos))
   }
 }

--- a/src/test/scala/io/circe/benchmarks/DecodingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/DecodingBenchmarkSpec.scala
@@ -8,26 +8,26 @@ class DecodingBenchmarkSpec extends FlatSpec with VersionSpecificDecodingSpec {
   import benchmark._
 
   "The decoding benchmark" should "correctly decode integers using Circe" in {
-    assert(decodeIntsC === ints)
+    assert(decodeIntsCirce === ints)
   }
 
   it should "correctly decode integers using Argonaut" in {
-    assert(decodeIntsA === ints)
+    assert(decodeIntsArgonaut === ints)
   }
 
   it should "correctly decode integers using Spray JSON" in {
-    assert(decodeIntsS === ints)
+    assert(decodeIntsSpray === ints)
   }
 
   it should "correctly decode case classes using Circe" in {
-    assert(decodeFoosC === foos)
+    assert(decodeFoosCirce === foos)
   }
 
   it should "correctly decode case classes using Argonaut" in {
-    assert(decodeFoosA === foos)
+    assert(decodeFoosArgonaut === foos)
   }
 
   it should "correctly decode case classes using Spray JSON" in {
-    assert(decodeFoosS === foos)
+    assert(decodeFoosSpray === foos)
   }
 }

--- a/src/test/scala/io/circe/benchmarks/EncodingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/EncodingBenchmarkSpec.scala
@@ -15,26 +15,26 @@ class EncodingBenchmarkSpec extends FlatSpec with VersionSpecificEncodingSpec {
     Parse.decodeOption[Map[String, Foo]](json)
 
   "The encoding benchmark" should "correctly encode integers using Circe" in {
-    assert(decodeInts(encodeIntsC.noSpaces) === Some(ints))
+    assert(decodeInts(encodeIntsCirce.noSpaces) === Some(ints))
   }
 
   it should "correctly encode integers using Argonaut" in {
-    assert(decodeInts(encodeIntsA.nospaces) === Some(ints))
+    assert(decodeInts(encodeIntsArgonaut.nospaces) === Some(ints))
   }
 
   it should "correctly encode integers using Spray JSON" in {
-    assert(decodeInts(encodeIntsS.compactPrint) === Some(ints))
+    assert(decodeInts(encodeIntsSpray.compactPrint) === Some(ints))
   }
 
   it should "correctly encode case classes using Circe" in {
-    assert(decodeFoos(encodeFoosC.noSpaces) === Some(foos))
+    assert(decodeFoos(encodeFoosCirce.noSpaces) === Some(foos))
   }
 
   it should "correctly encode case classes using Argonaut" in {
-    assert(decodeFoos(encodeFoosA.nospaces) === Some(foos))
+    assert(decodeFoos(encodeFoosArgonaut.nospaces) === Some(foos))
   }
 
   it should "correctly encode case classes using Spray JSON" in {
-    assert(decodeFoos(encodeFoosS.compactPrint) === Some(foos))
+    assert(decodeFoos(encodeFoosSpray.compactPrint) === Some(foos))
   }
 }

--- a/src/test/scala/io/circe/benchmarks/ParsingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/ParsingBenchmarkSpec.scala
@@ -8,26 +8,26 @@ class ParsingBenchmarkSpec extends FlatSpec with VersionSpecificParsingSpec {
   import benchmark._
 
   "The parsing benchmark" should "correctly parse integers using Circe" in {
-    assert(parseIntsC === intsC)
+    assert(parseIntsCirce === intsC)
   }
 
   it should "correctly parse integers using Argonaut" in {
-    assert(parseIntsA === intsA)
+    assert(parseIntsArgonaut === intsA)
   }
 
   it should "correctly parse integers using Spray JSON" in {
-    assert(parseIntsS === intsS)
+    assert(parseIntsSpray === intsS)
   }
 
   it should "correctly parse case classes using Circe" in {
-    assert(parseFoosC === foosC)
+    assert(parseFoosCirce === foosC)
   }
 
   it should "correctly parse case classes using Argonaut" in {
-    assert(parseFoosA === foosA)
+    assert(parseFoosArgonaut === foosA)
   }
 
   it should "correctly parse case classes using Spray JSON" in {
-    assert(parseFoosS === foosS)
+    assert(parseFoosSpray === foosS)
   }
 }

--- a/src/test/scala/io/circe/benchmarks/PrintingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/PrintingBenchmarkSpec.scala
@@ -15,26 +15,26 @@ class PrintingBenchmarkSpec extends FlatSpec with VersionSpecificPrintingSpec {
     Parse.decodeOption[Map[String, Foo]](json)
 
   "The printing benchmark" should "correctly print integers using Circe" in {
-    assert(decodeInts(printIntsC) === Some(ints))
+    assert(decodeInts(printIntsCirce) === Some(ints))
   }
 
   it should "correctly print integers using Argonaut" in {
-    assert(decodeInts(printIntsA) === Some(ints))
+    assert(decodeInts(printIntsArgonaut) === Some(ints))
   }
 
   it should "correctly print integers using Spray JSON" in {
-    assert(decodeInts(printIntsS) === Some(ints))
+    assert(decodeInts(printIntsSpray) === Some(ints))
   }
 
   it should "correctly print case classes using Circe" in {
-    assert(decodeFoos(printFoosC) === Some(foos))
+    assert(decodeFoos(printFoosCirce) === Some(foos))
   }
 
   it should "correctly print case classes using Argonaut" in {
-    assert(decodeFoos(printFoosA) === Some(foos))
+    assert(decodeFoos(printFoosArgonaut) === Some(foos))
   }
 
   it should "correctly print case classes using Spray JSON" in {
-    assert(decodeFoos(printFoosS) === Some(foos))
+    assert(decodeFoos(printFoosSpray) === Some(foos))
   }
 }


### PR DESCRIPTION
See #11 

It was trivial to expand the single-letter names, and this helps with comprehension of the test output. We could also reorganise the benchmarks into packages to give a different structure to the names, but that's a bit more work.