### PR TITLE
Use circe-derivation, fix tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ val baseSettings = Seq(
 
 val circeDependencies = Seq(
   "io.circe" %% "circe-core",
+  "io.circe" %% "circe-jackson28",
   "io.circe" %% "circe-jawn"
 ).map(_ % circeVersion)
 
@@ -52,11 +53,10 @@ lazy val benchmark = project.in(file("."))
   .settings(
     libraryDependencies ++= Seq(
       "io.argonaut" %% "argonaut" % "6.2",
-      "io.circe" %% "circe-derivation" % "0.8.0-M2",
       "io.spray" %% "spray-json" % "1.3.3",
       "org.json4s" %% "json4s-jackson" % "3.5.2",
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
-      "com.fasterxml.jackson.module"  %% "jackson-module-scala" % "2.8.4",
+      "com.fasterxml.jackson.module"  %% "jackson-module-scala" % "2.8.8",
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     ),
     libraryDependencies ++= circeDependencies,
@@ -64,7 +64,8 @@ lazy val benchmark = project.in(file("."))
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 10)) => Nil
         case _ => Seq(
-          "com.typesafe.play" %% "play-json" % "2.6.0-M7"
+          "com.typesafe.play" %% "play-json" % "2.6.0-RC1",
+          "io.circe" %% "circe-derivation" % "0.8.0-M2"
         )
       }
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -52,10 +52,11 @@ lazy val benchmark = project.in(file("."))
   .settings(
     libraryDependencies ++= Seq(
       "io.argonaut" %% "argonaut" % "6.2",
+      "io.circe" %% "circe-derivation" % "0.8.0-M2",
       "io.spray" %% "spray-json" % "1.3.3",
       "org.json4s" %% "json4s-jackson" % "3.5.2",
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
-      "com.fasterxml.jackson.module"  %% "jackson-module-scala"     % "2.8.4",
+      "com.fasterxml.jackson.module"  %% "jackson-module-scala" % "2.8.4",
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     ),
     libraryDependencies ++= circeDependencies,

--- a/src/main/scala-2.10/io/circe/benchmarks/CirceDefinitions.scala
+++ b/src/main/scala-2.10/io/circe/benchmarks/CirceDefinitions.scala
@@ -1,0 +1,25 @@
+package io.circe.benchmarks
+
+import io.circe.{ Decoder, Encoder, HCursor, Json }, io.circe.syntax._
+
+trait CirceFooInstances {
+  implicit val circeEncodeFoo: Encoder[Foo] = new Encoder[Foo] {
+    def apply(foo: Foo): Json = Json.obj(
+      "s" -> foo.s.asJson,
+      "d" -> foo.d.asJson,
+      "i" -> foo.i.asJson,
+      "l" -> foo.l.asJson,
+      "bs" -> foo.bs.asJson
+    )
+  }
+
+  implicit val circeDecodeFoo: Decoder[Foo] = new Decoder[Foo] {
+    def apply(c: HCursor): Decoder.Result[Foo] = for {
+      s <- c.get[String]("s").right
+      d <- c.get[Double]("d").right
+      i <- c.get[Int]("i").right
+      l <- c.get[Long]("l").right
+      bs <- c.get[List[Boolean]]("bs").right
+    } yield Foo(s, d, i, l, bs)
+  }
+}

--- a/src/main/scala-2.11/io/circe/benchmarks/CirceDefinitions.scala
+++ b/src/main/scala-2.11/io/circe/benchmarks/CirceDefinitions.scala
@@ -1,0 +1,8 @@
+package io.circe.benchmarks
+
+import io.circe.{ Decoder, Encoder }
+
+trait CirceFooInstances {
+  implicit val circeEncodeFoo: Encoder[Foo] = io.circe.derivation.deriveEncoder
+  implicit val circeDecodeFoo: Decoder[Foo] = io.circe.derivation.deriveDecoder
+}

--- a/src/main/scala-2.12/io/circe/benchmarks/CirceDefinitions.scala
+++ b/src/main/scala-2.12/io/circe/benchmarks/CirceDefinitions.scala
@@ -1,0 +1,8 @@
+package io.circe.benchmarks
+
+import io.circe.{ Decoder, Encoder }
+
+trait CirceFooInstances {
+  implicit val circeEncodeFoo: Encoder[Foo] = io.circe.derivation.deriveEncoder
+  implicit val circeDecodeFoo: Decoder[Foo] = io.circe.derivation.deriveDecoder
+}

--- a/src/main/scala/io/circe/benchmarks/CirceDefinitions.scala
+++ b/src/main/scala/io/circe/benchmarks/CirceDefinitions.scala
@@ -1,28 +1,11 @@
 package io.circe.benchmarks
 
-import io.circe._, io.circe.jawn.parse, io.circe.syntax._
+import io.circe._, io.circe.jawn.parse
 import org.openjdk.jmh.annotations._
 
 trait CirceFooInstances {
-  implicit val circeEncodeFoo: Encoder[Foo] = new Encoder[Foo] {
-    def apply(foo: Foo): Json = Json.obj(
-      "s" -> foo.s.asJson,
-      "d" -> foo.d.asJson,
-      "i" -> foo.i.asJson,
-      "l" -> foo.l.asJson,
-      "bs" -> foo.bs.asJson
-    )
-  }
-
-  implicit val circeDecodeFoo: Decoder[Foo] = new Decoder[Foo] {
-    def apply(c: HCursor): Decoder.Result[Foo] = for {
-      s <- c.get[String]("s").right
-      d <- c.get[Double]("d").right
-      i <- c.get[Int]("i").right
-      l <- c.get[Long]("l").right
-      bs <- c.get[List[Boolean]]("bs").right
-    } yield Foo(s, d, i, l, bs)
-  }
+  implicit val circeEncodeFoo: Encoder[Foo] = io.circe.derivation.deriveEncoder
+  implicit val circeDecodeFoo: Decoder[Foo] = io.circe.derivation.deriveDecoder
 }
 
 trait CirceData { self: ExampleData =>

--- a/src/main/scala/io/circe/benchmarks/CirceDefinitions.scala
+++ b/src/main/scala/io/circe/benchmarks/CirceDefinitions.scala
@@ -1,12 +1,7 @@
 package io.circe.benchmarks
 
-import io.circe._, io.circe.jawn.parse
+import io.circe._, io.circe.jackson, io.circe.jawn.parse
 import org.openjdk.jmh.annotations._
-
-trait CirceFooInstances {
-  implicit val circeEncodeFoo: Encoder[Foo] = io.circe.derivation.deriveEncoder
-  implicit val circeDecodeFoo: Decoder[Foo] = io.circe.derivation.deriveDecoder
-}
 
 trait CirceData { self: ExampleData =>
   @inline def encodeC[A](a: A)(implicit encode: Encoder[A]): Json = encode(a)
@@ -37,6 +32,12 @@ trait CircePrinting { self: ExampleData =>
 
   @Benchmark
   def printIntsCirce: String = intsC.noSpaces
+
+  @Benchmark
+  def printFoosCirceJackson: String = jackson.jacksonPrint(foosC)
+
+  @Benchmark
+  def printIntsCirceJackson: String = jackson.jacksonPrint(intsC)
 }
 
 trait CirceParsing { self: ExampleData =>
@@ -45,4 +46,10 @@ trait CirceParsing { self: ExampleData =>
 
   @Benchmark
   def parseIntsCirce: Json = parse(intsJson).right.getOrElse(throw new Exception)
+
+  @Benchmark
+  def parseFoosCirceJackson: Json = jackson.parse(foosJson).right.getOrElse(throw new Exception)
+
+  @Benchmark
+  def parseIntsCirceJackson: Json = jackson.parse(intsJson).right.getOrElse(throw new Exception)
 }

--- a/src/test/scala/io/circe/benchmarks/DecodingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/DecodingBenchmarkSpec.scala
@@ -19,6 +19,14 @@ class DecodingBenchmarkSpec extends FlatSpec with VersionSpecificDecodingSpec {
     assert(decodeIntsSpray === ints)
   }
 
+  it should "correctly decode integers using Json4s" in {
+    assert(decodeInts4s === ints)
+  }
+
+  it should "correctly decode integers using Jackson" in {
+    assert(decodeIntsJackson === ints)
+  }
+
   it should "correctly decode case classes using Circe" in {
     assert(decodeFoosCirce === foos)
   }
@@ -33,5 +41,9 @@ class DecodingBenchmarkSpec extends FlatSpec with VersionSpecificDecodingSpec {
 
   it should "correctly decode case classes using Json4s" in {
     assert(decodeFoos4s === foos)
+  }
+
+  it should "correctly decode case classes using Jackson" in {
+    assert(decodeFoosJackson === foos)
   }
 }

--- a/src/test/scala/io/circe/benchmarks/EncodingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/EncodingBenchmarkSpec.scala
@@ -28,6 +28,14 @@ class EncodingBenchmarkSpec extends FlatSpec with VersionSpecificEncodingSpec {
     assert(decodeInts(encodeIntsSpray.compactPrint) === Some(ints))
   }
 
+  it should "correctly encode integers using Json4s" in {
+    assert(decodeInts(JsonMethods.compact(encodeInts4s)) === Some(ints))
+  }
+
+  it should "correctly encode integers using Jackson" in {
+    assert(decodeInts(mapper.writeValueAsString(encodeIntsJackson)) === Some(ints))
+  }
+
   it should "correctly encode case classes using Circe" in {
     assert(decodeFoos(encodeFoosCirce.noSpaces) === Some(foos))
   }
@@ -42,5 +50,9 @@ class EncodingBenchmarkSpec extends FlatSpec with VersionSpecificEncodingSpec {
 
   it should "correctly encode case classes using Json4s" in {
     assert(decodeFoos(JsonMethods.compact(encodeFoos4s)) === Some(foos))
+  }
+
+  it should "correctly encode case classes using Jackson" in {
+    assert(decodeFoos(mapper.writeValueAsString(encodeFoosJackson)) === Some(foos))
   }
 }

--- a/src/test/scala/io/circe/benchmarks/ParsingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/ParsingBenchmarkSpec.scala
@@ -11,6 +11,10 @@ class ParsingBenchmarkSpec extends FlatSpec with VersionSpecificParsingSpec {
     assert(parseIntsCirce === intsC)
   }
 
+  it should "correctly parse integers using Circe Jackson" in {
+    assert(parseIntsCirceJackson === intsC)
+  }
+
   it should "correctly parse integers using Argonaut" in {
     assert(parseIntsArgonaut === intsA)
   }
@@ -19,8 +23,20 @@ class ParsingBenchmarkSpec extends FlatSpec with VersionSpecificParsingSpec {
     assert(parseIntsSpray === intsS)
   }
 
+  it should "correctly parse integers using Json4s" in {
+    assert(parseInts4s === ints4s)
+  }
+
+  it should "correctly parse integers using Jackson" in {
+    assert(parseIntsJackson === intsJackson)
+  }
+
   it should "correctly parse case classes using Circe" in {
     assert(parseFoosCirce === foosC)
+  }
+
+  it should "correctly parse case classes using Circe Jackson" in {
+    assert(parseFoosCirceJackson === foosC)
   }
 
   it should "correctly parse case classes using Argonaut" in {
@@ -33,5 +49,13 @@ class ParsingBenchmarkSpec extends FlatSpec with VersionSpecificParsingSpec {
 
   it should "correctly parse case classes using Json4s" in {
     assert(parseFoos4s === foos4s)
+  }
+
+  it should "correctly parse case classes using Jackson" in {
+    /**
+     * A workaround for the fact that I don't remember how `JsonNode` equality
+     * works in Jackson.
+     */
+    assert(mapper.writeValueAsString(parseFoosJackson) === mapper.writeValueAsString(foosJackson))
   }
 }

--- a/src/test/scala/io/circe/benchmarks/PrintingBenchmarkSpec.scala
+++ b/src/test/scala/io/circe/benchmarks/PrintingBenchmarkSpec.scala
@@ -18,6 +18,10 @@ class PrintingBenchmarkSpec extends FlatSpec with VersionSpecificPrintingSpec {
     assert(decodeInts(printIntsCirce) === Some(ints))
   }
 
+  it should "correctly print integers using Circe Jackson" in {
+    assert(decodeInts(printIntsCirceJackson) === Some(ints))
+  }
+
   it should "correctly print integers using Argonaut" in {
     assert(decodeInts(printIntsArgonaut) === Some(ints))
   }
@@ -26,8 +30,20 @@ class PrintingBenchmarkSpec extends FlatSpec with VersionSpecificPrintingSpec {
     assert(decodeInts(printIntsSpray) === Some(ints))
   }
 
+  it should "correctly print integers using Json4s" in {
+    assert(decodeInts(printInts4s) === Some(ints))
+  }
+
+  it should "correctly print integers using Jackson" in {
+    assert(decodeInts(printIntsJackson) === Some(ints))
+  }
+
   it should "correctly print case classes using Circe" in {
     assert(decodeFoos(printFoosCirce) === Some(foos))
+  }
+
+  it should "correctly print case classes using Circe Jackson" in {
+    assert(decodeFoos(printFoosCirceJackson) === Some(foos))
   }
 
   it should "correctly print case classes using Argonaut" in {
@@ -38,7 +54,11 @@ class PrintingBenchmarkSpec extends FlatSpec with VersionSpecificPrintingSpec {
     assert(decodeFoos(printFoosSpray) === Some(foos))
   }
 
-  it should "correnctly print case classes using Json4s" in {
+  it should "correctly print case classes using Json4s" in {
     assert(decodeFoos(printFoos4s) === Some(foos))
+  }
+
+  it should "correctly print case classes using Jackson" in {
+    assert(decodeFoos(printFoosJackson) === Some(foos))
   }
 }


### PR DESCRIPTION
This PR does five things: updates some miscellaneous versions, switches to circe-derivation for 2.11 and 2.11 (which is actually almost 10% faster than the manual definition for decoding, because it avoids `flatMap`), fixes some tests that either weren't there or were broken, changes the Jackson benchmarks to follow the same definitions as the others, and adds new circe-jackson benchmarks.