### PR TITLE
Miscellaneous updates including circe milestone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: required
 dist: trusty
 
 scala:
-  - 2.10.6
-  - 2.11.11
+  - 2.10.7
+  - 2.11.12
   - 2.12.4
 
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val compilerOptions = Seq(
   "-Xfuture"
 )
 
-val circeVersion = "0.9.0-M1"
+val circeVersion = "0.9.0-M2"
 val scalaTestVersion = "3.0.4"
 
 val baseSettings = Seq(
@@ -53,7 +53,7 @@ lazy val benchmark = project.in(file("."))
   .settings(
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.10",
-      "com.typesafe.play" %% "play-json" % "2.6.6",
+      "com.typesafe.play" %% "play-json" % "2.6.7",
       "io.argonaut" %% "argonaut" % "6.2",
       "io.spray" %% "spray-json" % "1.3.3",
       "org.json4s" %% "json4s-jackson" % "3.5.3",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.0.4


### PR DESCRIPTION
Note that circe-derivation isn't published for circe 0.9.0-M2 yet, but given that it's some fairly simple macros that doesn't cause a problem here. Example results on 2.12 (larger numbers are better):

```
Benchmark                           Mode  Cnt      Score     Error  Units
ReadingBenchmark.readFoosJackson   thrpt   40   4870.246 ± 116.777  ops/s
ReadingBenchmark.readFoosCirce     thrpt   40   3594.174 ±  89.991  ops/s
ReadingBenchmark.readFoosSpray     thrpt   40   2195.550 ±  10.504  ops/s
ReadingBenchmark.readFoosArgonaut  thrpt   40   1417.696 ±  34.051  ops/s
ReadingBenchmark.readFoosPlay      thrpt   40   1230.855 ±  16.072  ops/s
ReadingBenchmark.readFoosJson4s    thrpt   40   1019.111 ±  35.642  ops/s

ReadingBenchmark.readIntsJackson   thrpt   40  40759.460 ± 519.453  ops/s
ReadingBenchmark.readIntsCirce     thrpt   40  18163.783 ± 175.334  ops/s
ReadingBenchmark.readIntsSpray     thrpt   40  16169.084 ± 257.248  ops/s
ReadingBenchmark.readIntsPlay      thrpt   40   9474.730 ± 249.813  ops/s
ReadingBenchmark.readIntsArgonaut  thrpt   40   8090.080 ± 263.154  ops/s
ReadingBenchmark.readIntsJson4s    thrpt   40   5323.065 ± 102.737  ops/s
```
And:
```
Benchmark                            Mode  Cnt      Score     Error  Units
WritingBenchmark.writeFoosJackson   thrpt   40   8908.667 ±  73.555  ops/s
WritingBenchmark.writeFoosCirce     thrpt   40   3099.720 ± 135.503  ops/s
WritingBenchmark.writeFoosSpray     thrpt   40   3014.840 ±  22.500  ops/s
WritingBenchmark.writeFoosPlay      thrpt   40   2304.416 ±  94.253  ops/s
WritingBenchmark.writeFoosArgonaut  thrpt   40   2289.967 ±  78.733  ops/s
WritingBenchmark.writeFoosJson4s    thrpt   40    961.887 ±  17.216  ops/s

WritingBenchmark.writeIntsJackson   thrpt   40  87053.956 ± 860.368  ops/s
WritingBenchmark.writeIntsCirce     thrpt   40  32592.988 ± 359.259  ops/s
WritingBenchmark.writeIntsSpray     thrpt   40  16881.522 ±  94.270  ops/s
WritingBenchmark.writeIntsArgonaut  thrpt   40  15472.784 ±  99.060  ops/s
WritingBenchmark.writeIntsJson4s    thrpt   40   4141.836 ±  82.988  ops/s
WritingBenchmark.writeIntsPlay      thrpt   40   4080.547 ±  28.522  ops/s
```